### PR TITLE
Low memory options

### DIFF
--- a/TowerTools_ForcingData/flow.api.clm.R
+++ b/TowerTools_ForcingData/flow.api.clm.R
@@ -49,7 +49,7 @@ TimeAgr <- 30
 dateBgn <- "2019-01-01"
 
 #End date for date grabbing
-dateEnd <- "2019-11-30"
+dateEnd <- "2019-09-30"
 
 #The version data for the FP standard conversion processing
 ver <- paste0("v",format(Sys.time(), "%Y%m%dT%H%m"))


### PR DESCRIPTION
Adds an option for running stackEddy() in batches to decrease the memory load. This was implemented so that I could download 12 months of data on my laptop which has 16GB of ram.

The change does the following:
Moves the zipped data files from `/filesToStack00200/` to subdirectories, each of which contains a specified number of months of data. The flux data for each subdirectory is then compiled into a data frame, these steps happen in a loop which takes more time, but uses less total memory at any moment. Finally the dataframes are concatenated into a final dataframe containing the entire time series. 